### PR TITLE
Fixed `marvel.creators.findByName` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ marvel.creators.findByName('austin')
 Fetch by first and middle name only.
 
 ```js
-marvel.creators.findByName('austin', 'dave')
+marvel.creators.findByName('Goran', 'Sudzuka')
   .then(console.log)
   .fail(console.error)
   .done();
@@ -263,7 +263,7 @@ marvel.creators.findByName('austin', 'dave')
 Fetch by first, middle, and last name.
 
 ```js
-marvel.creators.findByName('austin', 'dave', 'cam')
+marvel.creators.findByName('Pat', 'Lee', '(X-Men/FF)')
   .then(console.log)
   .fail(console.error)
   .done();

--- a/lib/creators.js
+++ b/lib/creators.js
@@ -78,17 +78,25 @@ module.exports = function(options, utils) {
       last = '';
     }
 
-    request({
-      url: 'http://gateway.marvel.com/v1/public/creators'
-    , json: true
-    , qs: {
+    var qs = {
         ts: ts
       , apikey: pubkey
       , hash: utils.createHash(ts, privkey, pubkey)
       , firstName: first
-      , middleName: middle || ''
-      , lastName: last || ''
-      }
+      };
+
+    if (middle) {
+      qs.middleName = middle;
+    }
+
+    if (last) {
+      qs.lastName = last;
+    }
+
+    request({
+      url: 'http://gateway.marvel.com/v1/public/creators'
+    , json: true
+    , qs: qs
     }, function(err, response) {
       if (err) {
         return deferred.reject(err);

--- a/spec/creator-spec.js
+++ b/spec/creator-spec.js
@@ -80,7 +80,7 @@ describe('creators', function() {
 
   it('should call #findByName with just a first name', function(done) {
     var route = util.format(
-      '/v1/public/creators?ts=%s&apikey=public-test&hash=%s&firstName=austin&middleName=&lastName='
+      '/v1/public/creators?ts=%s&apikey=public-test&hash=%s&firstName=austin'
     , ts
     , hash);
 
@@ -98,7 +98,7 @@ describe('creators', function() {
 
   it('should call #findByName with a first and middle name', function(done) {
     var route = util.format(
-      '/v1/public/creators?ts=%s&apikey=public-test&hash=%s&firstName=austin&middleName=dave&lastName='
+      '/v1/public/creators?ts=%s&apikey=public-test&hash=%s&firstName=austin&middleName=dave'
     , ts
     , hash);
 
@@ -232,7 +232,7 @@ describe('creators', function() {
 
     it('should catch errors from #findByName', function(done) {
       var route = util.format(
-        '/v1/public/creators?ts=%s&apikey=public-test&hash=%s&firstName=test-man&middleName=&lastName='
+        '/v1/public/creators?ts=%s&apikey=public-test&hash=%s&firstName=test-man'
       , ts
       , hash);
 


### PR DESCRIPTION
Hi, I found that `marvel.creators.findByName` function doesn't work.

* Fetch by first name only : :ng: 
* Fetch by first and middle name only : :ng: 
* Fetch by first, middle, and last name : :ok: 

Because, `middleName` and `lastName` are not allowed blank.

```js
// debug code
console.log(response.statusCode); // 409
console.log(response.body); // { code: 409, status: 'lastName cannot be blank if it is set' }
```

# After fixed

## code

```js
marvel.creators.findByName('austin')
  .then(console.log)
  .fail(console.error)
  .done();

marvel.creators.findByName('Goran', 'Sudzuka')
  .then(console.log)
  .fail(console.error)
  .done();

marvel.creators.findByName('Pat', 'Lee', '(X-Men/FF)')
  .then(console.log)
  .fail(console.error)
  .done();
```

## result

```
{ data:
   [ { id: 2935,
       firstName: 'Austin',
       middleName: '',
       lastName: '',
       suffix: '',
       fullName: 'Austin',
       modified: '2007-01-02T00:00:00-0500',
       thumbnail: [Object],
       resourceURI: 'http://gateway.marvel.com/v1/public/creators/2935',
       comics: [Object],
       series: [Object],
       stories: [Object],
       events: [Object],
       urls: [Object] } ],
  meta: { offset: 0, limit: 20, total: 1, count: 1 } }
{ data:
   [ { id: 11479,
       firstName: 'Goran',
       middleName: 'Sudzuka',
       lastName: '',
       suffix: '',
       fullName: 'Goran Sudzuka',
       modified: '2011-10-03T17:17:54-0400',
       thumbnail: [Object],
       resourceURI: 'http://gateway.marvel.com/v1/public/creators/11479',
       comics: [Object],
       series: [Object],
       stories: [Object],
       events: [Object],
       urls: [Object] } ],
  meta: { offset: 0, limit: 20, total: 1, count: 1 } }
{ data:
   [ { id: 9215,
       firstName: 'Pat',
       middleName: 'Lee',
       lastName: '(X-Men/FF)',
       suffix: '',
       fullName: 'Pat Lee (X-Men/FF)',
       modified: '2007-01-02T00:00:00-0500',
       thumbnail: [Object],
       resourceURI: 'http://gateway.marvel.com/v1/public/creators/9215',
       comics: [Object],
       series: [Object],
       stories: [Object],
       events: [Object],
       urls: [Object] } ],
  meta: { offset: 0, limit: 20, total: 1, count: 1 } }
```

# Fixed README.md

`('austin', 'dave')` and `('austin', 'dave', 'cam')` parameters don't exist, so that fixed correct parameters.

# Testing

```
➜  marvel-api git:(fix-creators) ✗ make test
  174 passing (454ms)
```

Thank you :+1: 